### PR TITLE
Added option for custom degrees

### DIFF
--- a/src/radial.js
+++ b/src/radial.js
@@ -101,12 +101,23 @@
 	}
 	
 	// Class
-	var Radial = function(items, newOptions) {
+	var Radial = function(items, newOptions, degrees) {
 		this.options = extendOpt(options, newOptions || {});
 		this._items = extendOptions(items);
+		if(!(degrees===undefined)){ //if it is NOT undefined
+			for(var i = 0; i<this._items.length; i++){
+				if(!(degrees[i]===undefined)){
+					this._items[i]._alfa = degrees[i];
+				}
+				else{
+					this._items[i]._alfa = 0;
+				}
+			}
+		}
 		this._container = createContainer(this.options.container);
 		this.calc();
 	};
+	
 	
 	Radial.prototype = {
 		
@@ -171,7 +182,28 @@
 		*/
 		calc: function() {
 			var count = (this.options.button) ? this.count()-1 : this.count();
-			var alfa = (this.options.deg > 359) ? 360/count : this.options.deg/(count-1);
+			var newcount = count;
+			var anglesaccountedfor = 0;
+			for(var k = 0; k<this._items.length; k++){
+				anglesaccountedfor += this._items[k]._alfa;
+				if(this._items[k]._alfa != 0 && this.options.button){
+					newcount--;
+				}
+			}
+			if((anglesaccountedfor > this.options.deg) || (anglesaccountedfor > 360)){
+				for(var k = 0; k<this._items.length; k++){
+					this._items[k]._alfa = 0; //if the angles don't add up then reset all values to default
+					anglesaccountedfor = 0;
+					newcount = count;
+				}
+			}
+			var alfa = 0;
+			if(newcount != 0){
+				alfa = (this.options.deg > 359) ? (360-anglesaccountedfor)/newcount : (this.options.deg-anglesaccountedfor)/(newcount-1);
+			}
+			else{
+				alfa = (this.options.deg > 359) ? (360-anglesaccountedfor)/count : (this.options.deg-anglesaccountedfor)/(count-1);
+			}
 			var i = -alfa;
 			var j = 0;
 			if(this.options.button) {
@@ -180,9 +212,15 @@
 				j++;
 				count++;
 			}
-			for(j; j < count; j++) {
-				var newalfa = Math.round(i + alfa);
-				this._items[j]._alfa = newalfa;
+			for(j; j < this._items.length; j++) {
+				if(newcount != 0){
+					var newalfa = (this._items[j]._alfa == 0) ? Math.round(i + alfa) : Math.round(i + this._items[j]._alfa);
+					this._items[j]._alfa = newalfa;
+				}
+				else{
+					var newalfa = Math.round(i + alfa);
+					this._items[j]._alfa += newalfa;
+				}
 				i = newalfa;
 			}
 			


### PR DESCRIPTION
I added a way to add custom degrees for some nodes. So if you want a menu that has unevenly distributed items, you can do that. So if you had 3 radial non button nodes, and you wanted one to be 100 degrees apart from the next and not 120, you could make it 100, 130, 130 degrees apart from each other

To do so I added an optional parameter for degrees you can declare by making a vector full of "degrees." I added a check to make sure degrees is declared, and played with the math a little to make sure that all the nodes that don't have a custom degree are distributed equally around the circle. 

Any undefined degrees ie the degree vector is shorter than item count, the remaining degrees will count as 0. 

If the user's degrees add up to over 360 or whatever max degree they specify, degrees will all reset to 0. 

If the user uses custom degrees for ALL nodes but it adds up to less than 360, then this will add extra angle to compensate. 
